### PR TITLE
Add export for authorizer lambda ARN.

### DIFF
--- a/lib/lambda-auth-stack.ts
+++ b/lib/lambda-auth-stack.ts
@@ -45,5 +45,10 @@ export default class LambdaAuthStack extends Stack {
       value: authFunction.functionName,
       exportName: `${props.stackName}:LambdaName`,
     })
+
+    new CfnOutput(this, 'LambdaArnExport', {
+      value: authFunction.functionArn,
+      exportName: `${props.stackName}Arn`, // Named for backwards compatibility
+    })
   }
 }


### PR DESCRIPTION
The cloudformation had this export, so adding it here in case any other stacks are importing it. That way we don't have to update dependent stacks.